### PR TITLE
VPNaaS: move vpn subnet to ipsec connection

### DIFF
--- a/midonet/neutron/services/vpn/service_drivers/midonet_ipsec.py
+++ b/midonet/neutron/services/vpn/service_drivers/midonet_ipsec.py
@@ -140,6 +140,9 @@ class MidonetIPsecVPNDriver(base_ipsec.BaseIPsecVPNDriver):
                 lambda conn: conn['id'] == ipsec_site_conn_id,
                 vpnservice_dict['ipsec_site_connections']))[0]
 
+        # Move the subnet cidr into local_cidrs
+        vpn_subnet_cidr = vpnservice_dict['subnet']['cidr']
+        ipsec_site_conn_dict['local_cidrs'] = [vpn_subnet_cidr]
         return ipsec_site_conn_dict
 
     def update_vpn_service_status(self, context, vpnservice_id, status):


### PR DESCRIPTION
The backend models needed a change to support endpoint groups in future
neutron implementation. Specifically, the subnet id in vpnservice is no
longer used and instead two lists of subnet cidrs (both peer and local
subnets) are passed to the ipsec site connection object. Kilo doesn't
support end point groups so we just copy the vpnservice subnet cidr into
a list with just a single element in the ipsec site connection.

Besides, this patch makes the vpn service and ipsec site connection
update tests more specific to avoid regressions, as we also check that
the dtos sent to the midonet backend actually contain the expected
fields updated.

Change-Id: I261407b04b746663edd722861229a19b75fa3c8c
Signed-off-by: Xavi León xavi.leon@midokura.com
